### PR TITLE
Increase wait time EEA Screenshooter when saving preview image

### DIFF
--- a/cypress/e2e/block-tableau.cy.js
+++ b/cypress/e2e/block-tableau.cy.js
@@ -27,13 +27,18 @@ describe('Blocks Tests', () => {
   afterEach(slateAfterEach);
 
   it('Add Tableau block', () => {
+    cy.intercept('GET', `/**/*?expand*`, {
+      statusCode: 200,
+    }).as('content');
     // when I add a maps block
     cy.addNewBlock('tableau');
 
     cy.get(
       `.sidebar-container .field-wrapper-tableau_vis_url #field-tableau_vis_url`,
     ).type('/path/to/dashboard', { force: true });
+    cy.wait('@content');
     cy.get('#toolbar-save').click({ force: true });
+    cy.intercept('GET', `/**/*?expand*`).as('content');
     cy.wait('@content');
     cy.url().should('eq', Cypress.config().baseUrl + '/cypress/my-page');
   });

--- a/src/Widgets/VisualizationWidget.jsx
+++ b/src/Widgets/VisualizationWidget.jsx
@@ -139,7 +139,7 @@ const VisualizationWidget = (props) => {
           '',
         )}/cors-proxy/https://screenshot.eea.europa.eu/api/v1/retrieve_image_for_url?url=${encodeURIComponent(
           value.url,
-        )}&w=1920&h=1000&waitfor=4000`,
+        )}&w=1920&h=1000&waitfor=8000`,
       )
         .then((e) => e.blob())
         .then((myBlob) => {


### PR DESCRIPTION
After creating the script to save all the preview images of the existing content we saw that some of the Tableau are not fully loaded when the screenshooter is taking the picture